### PR TITLE
Fix logger include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(INC_CORE
     ${INC_DIR}/redox/command.hpp)
 
 set(SRC_UTILS ${SRC_DIR}/utils/logger.cpp)
-set(INC_UTILS ${INC_DIR}/utils/logger.hpp)
+set(INC_UTILS ${INC_DIR}/redox/utils/logger.hpp)
 
 set(INC_WRAPPER ${INC_DIR}/redox.hpp)
 


### PR DESCRIPTION
Fix the path for logger.hpp, otherwise make install fails.

Change-Id: I50aa9667e512c4fdf6de471dc16312d9eb3dbe30