### PR TITLE
Set CMAKE_INSTALL_PREFIX only when not externally set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,9 @@ endif()
 # Install (sudo make install)
 # ---------------------------------------------------------
 
-set(CMAKE_INSTALL_PREFIX /usr/)
+if(NOT CMAKE_INSTALL_PREFIX)
+   set(CMAKE_INSTALL_PREFIX /usr/)
+endif(NOT CMAKE_INSTALL_PREFIX)
 
 # Check if it is a 64 bit system
 if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT LIB_SUFFIX)


### PR DESCRIPTION
This PR enables changing  [`CMAKE_INSTALL_PREFIX`](http://www.cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html) variable when calling CMake (which should be the default behaviour). 

Example usage:

```bash
$ ~/redox> cmake . -DCMAKE_INSTALL_PREFIX=~/thirdpary
```