### PR TITLE
Add CMake find module for hiredis and libev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,26 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -Wall")
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # Print out compiler commands
 # set(CMAKE_VERBOSE_MAKEFILE ON)
+
+# ---------------------------------------------------------
+# Check for required dependencies
+# ---------------------------------------------------------
+if(CMAKE_VERSION VERSION_GREATER 2.8.5 OR CMAKE_VERSION VERSION_EQUAL 2.8.5)
+  include(GNUInstallDirs)
+endif()
+
+find_package(Threads REQUIRED)
+find_package(hiredis REQUIRED)
+find_package(libev REQUIRED)
+
+set(REDOX_LIB_DEPS
+  ${HIREDIS_LIBRARIES}
+  ${LIBEV_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT})
 
 # ---------------------------------------------------------
 # Source files
@@ -48,11 +65,6 @@ set(INC_REDOX_ALL ${INC_REDOX_CORE} ${INC_REDOX_UTILS} ${INC_REDOX_WRAPPER})
 
 include_directories(${INC_REDOX_DIR})
 include_directories(${INC_REDOX_DIR}/redox)
-
-# Dependent libraries - you may have to change
-# pthread to whatever C++11 threads depends on
-# for your platform
-set(REDOX_LIB_DEPS ev pthread hiredis)
 
 # ---------------------------------------------------------
 # Library generation

--- a/cmake/Findhiredis.cmake
+++ b/cmake/Findhiredis.cmake
@@ -1,0 +1,31 @@
+# Try to find hiredis
+# Once done, this will define
+#
+# HIREDIS_FOUND        - system has hiredis
+# HIREDIS_INCLUDE_DIRS - hiredis include directories
+# HIREDIS_LIBRARIES    - libraries need to use hiredis
+
+if(HIREDIS_INCLUDE_DIRS AND HIREDIS_LIBRARIES)
+  set(HIREDIS_FIND_QUIETLY TRUE)
+else()
+  find_path(
+    HIREDIS_INCLUDE_DIR
+    NAMES hiredis/hiredis.h
+    HINTS ${HIREDIS_ROOT_DIR}
+    PATH_SUFFIXES include)
+
+  find_library(
+    HIREDIS_LIBRARY
+    NAMES hiredis
+    HINTS ${HIREDIS_ROOT_DIR}
+    PATH_SUFFIXES ${CMAKE_INSTALL_LIBDIR})
+
+  set(HIREDIS_INCLUDE_DIRS ${HIREDIS_INCLUDE_DIR})
+  set(HIREDIS_LIBRARIES ${HIREDIS_LIBRARY})
+
+  include (FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    hiredis DEFAULT_MSG HIREDIS_LIBRARY HIREDIS_INCLUDE_DIR)
+
+  mark_as_advanced(HIREDIS_LIBRARY HIREDIS_INCLUDE_DIR)
+endif()

--- a/cmake/Findlibev.cmake
+++ b/cmake/Findlibev.cmake
@@ -1,0 +1,31 @@
+# Try to find libev
+# Once done, this will define
+#
+# LIBEV_FOUND        - system has libev
+# LIBEV_INCLUDE_DIRS - libev include directories
+# LIBEV_LIBRARIES    - libraries needed to use libev
+
+if(LIBEV_INCLUDE_DIRS AND LIBEV_LIBRARIES)
+  set(LIBEV_FIND_QUIETLY TRUE)
+else()
+  find_path(
+    LIBEV_INCLUDE_DIR
+    NAMES ev.h
+    HINTS ${LIBEV_ROOT_DIR}
+    PATH_SUFFIXES include)
+
+  find_library(
+    LIBEV_LIBRARY
+    NAME ev
+    HINTS ${LIBEV_ROOT_DIR}
+    PATH_SUFFIXES ${CMAKE_INSTALL_LIBDIR})
+
+  set(LIBEV_INCLUDE_DIRS ${LIBEV_INCLUDE_DIR})
+  set(LIBEV_LIBRARIES ${LIBEV_LIBRARY})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    libev DEFAULT_MSG LIBEV_LIBRARY LIBEV_INCLUDE_DIR)
+
+  mark_as_advanced(LIBEV_LIBRARY LIBEV_INCLUDE_DIR)
+endif()


### PR DESCRIPTION
Contains:
- add find module for hiredis and libev
- make compilation fail if dependencies not met 
- improve portability of the build and use if possible the GNUInstallDirs package (>= CMake 2.8.5)
