### PR TITLE
update cmake for hiredis and libev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ find_package(Threads REQUIRED)
 find_package(hiredis REQUIRED)
 find_package(libev REQUIRED)
 
+include_directories(${HIREDIS_INCLUDE_DIR})
+include_directories(${LIBEV_INCLUDE_DIR})
+
 set(REDOX_LIB_DEPS
   ${HIREDIS_LIBRARIES}
   ${LIBEV_LIBRARIES}


### PR DESCRIPTION
when I try to build redox with custom hiredis location,

```
mkdir build
cd build
cmake -DHIREDIS_ROOT_DIR=/home/fifilyu/workspace/third_party/hiredis ..
```

I get the following error:

> [fifilyu@archlinux build]$ make
> Scanning dependencies of target redox
> [  8%] Building CXX object CMakeFiles/redox.dir/src/client.cpp.o
> In file included from /home/fifilyu/workspace/redox/src/client.cpp:23:0:
> /home/fifilyu/workspace/redox/include/redox/client.hpp:37:29: fatal error: hiredis/hiredis.h: No such file or directory
