### PR TITLE
Undefine EV_ERROR before including ev.h

### DIFF
--- a/include/redox/client.hpp
+++ b/include/redox/client.hpp
@@ -36,6 +36,8 @@
 
 #include <hiredis/hiredis.h>
 #include <hiredis/async.h>
+
+#undef EV_ERROR
 #include <hiredis/adapters/libev.h>
 
 #include "utils/logger.hpp"

--- a/include/redox/command.hpp
+++ b/include/redox/command.hpp
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <condition_variable>
 
+#undef EV_ERROR
 #include <hiredis/adapters/libev.h>
 #include <hiredis/async.h>
 


### PR DESCRIPTION
libev's ev.h has certain defines that clash with system included
headers on both MacOS and Linux. On MacOS the clashing name comes
from /usr/include/sys/event.h:167:29 and on Linux from elf.h.

This issue is reported upstream to the maintainer as well.