### PR TITLE
Support generation of a pkg-config redox.pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 3.0.2)
 project(redox)
 
 set(REDOX_VERSION_MAJOR 0)
@@ -194,6 +194,8 @@ if (lib)
   # Install the dynamic library to /usr/lib[64]
   install(TARGETS redox DESTINATION lib${LIB_SUFFIX})
   # Generate the redox.pc pkg-config file in /usr/lib[64]/pkgconfig
+  get_filename_component(HIREDIS_LIBRARY_DIRECTORY ${HIREDIS_LIBRARIES} DIRECTORY)
+  get_filename_component(LIBEV_LIBRARY_DIRECTORY ${LIBEV_LIBRARIES} DIRECTORY)
   configure_file("${CMAKE_HOME_DIRECTORY}/cmake/redox.pc.in" "${PROJECT_BINARY_DIR}/redox.pc" @ONLY)
   install(FILES "${PROJECT_BINARY_DIR}/redox.pc" DESTINATION lib${LIB_SUFFIX}/pkgconfig/)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,9 @@ endif()
 if (lib)
   # Install the dynamic library to /usr/lib[64]
   install(TARGETS redox DESTINATION lib${LIB_SUFFIX})
+  # Generate the redox.pc pkg-config file in /usr/lib[64]/pkgconfig
+  configure_file("${CMAKE_HOME_DIRECTORY}/cmake/redox.pc.in" "${PROJECT_BINARY_DIR}/redox.pc" @ONLY)
+  install(FILES "${PROJECT_BINARY_DIR}/redox.pc" DESTINATION lib${LIB_SUFFIX}/pkgconfig/)
 endif()
 
 if (static_lib)

--- a/cmake/redox.pc.in
+++ b/cmake/redox.pc.in
@@ -7,5 +7,5 @@ Name: redox
 Description: Modern, asynchronous, and wicked fast C++11 client for Redis
 Version: @REDOX_VERSION_STRING@
 
-Libs: -L${libdir} -lredox @HIREDIS_LIBRARIES@ @LIBEV_LIBRARIES@ @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir}
+Libs: -L${libdir} -lredox -L@HIREDIS_LIBRARY_DIRECTORY@ -lhiredis -L@LIBEV_LIBRARY_DIRECTORY@ -lev @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} -I@HIREDIS_INCLUDE_DIRS@

--- a/cmake/redox.pc.in
+++ b/cmake/redox.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib@LIB_SUFFIX@
+includedir=${prefix}/include
+
+Name: redox
+Description: Modern, asynchronous, and wicked fast C++11 client for Redis
+Version: @REDOX_VERSION_STRING@
+
+Libs: -L${libdir} -lredox @HIREDIS_LIBRARIES@ @LIBEV_LIBRARIES@ @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir}


### PR DESCRIPTION
Hello,

This PR adds the generation of a [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) file for redox when calling `make/ninja/etc. install`.

In brief, pkg-config eases the utilization of software libraries by allowing the developers of a library to define how the library should be used — instead of letting end users struggling with it. It therefore allows redox users to link/include it without having to know internal details such as include path, the library name or the dependencies that should also be included/linked.

Some build systems support the definition of dependencies via pkg-config (e.g., this is the main way to define dependencies in [Meson](https://mesonbuild.com/), CMake can use pkg-config dependencies).

The following two examples show how a pkg-config redox file could help users by compiling the example located in `examples/basic.cpp` — after installing the new redox version. 

### Makefile usage example
``` Makefile
basic: basic.cpp
	g++ -o basic `pkg-config --cflags --libs redox` basic.cpp
```

### Meson usage example
``` meson
project('basic', 'cpp')
redox = dependency('redox')
executable('basic', 'basic.cpp', dependencies: redox)
```