### PR TITLE
Support commands returning vector<int>

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ a `WRONG_TYPE` or `NIL_REPLY` status.
  * `<std::vector<std::string>>`: Arrays of Simple Strings or Bulk Strings (in received order)
  * `<std::set<std::string>>`: Arrays of Simple Strings or Bulk Strings (in sorted order)
  * `<std::unordered_set<std::string>>`: Arrays of Simple Strings or Bulk Strings (in no order)
+ * `<std::vector<int>>`: Arrays of integers (in received order)
 
 ## Installation
 Instructions provided are for Ubuntu, but all components are platform-independent.

--- a/examples/data_types.cpp
+++ b/examples/data_types.cpp
@@ -46,6 +46,18 @@ int main(int argc, char* argv[]) {
         for (const string& s : c.reply()) cout << s << " ";
         cout << endl;
       }
+    }
+  );
+
+  rdx.del("myset");
+  rdx.commandSync(rdx.strToVec("SADD myset 2 3 5 7 11 13 17 19"));
+  rdx.command<vector<int>>(rdx.strToVec("SMISMEMBER myset 1 2 3 4 5"),
+    [&rdx](Command<vector<int>>& c) {
+      if(c.ok()) {
+        cout << "Are {1, 2, 3, 4, 5} in the set, respectively: ";
+        for (int i : c.reply()) cout << i << " ";
+        cout << endl;
+      }
       rdx.stop();
     }
   );

--- a/include/redox/client.hpp
+++ b/include/redox/client.hpp
@@ -372,6 +372,7 @@ private:
   std::unordered_map<long, Command<long long int> *> commands_long_long_int_;
   std::unordered_map<long, Command<std::nullptr_t> *> commands_null_;
   std::unordered_map<long, Command<std::vector<std::string>> *> commands_vector_string_;
+  std::unordered_map<long, Command<std::vector<int>> *> commands_vector_int_;
   std::unordered_map<long, Command<std::set<std::string>> *> commands_set_string_;
   std::unordered_map<long, Command<std::unordered_set<std::string>> *>
       commands_unordered_set_string_;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -459,6 +459,7 @@ void Redox::processQueuedCommands(struct ev_loop *loop, ev_async *async, int rev
     } else if (rdx->processQueuedCommand<long long int>(id)) {
     } else if (rdx->processQueuedCommand<nullptr_t>(id)) {
     } else if (rdx->processQueuedCommand<vector<string>>(id)) {
+    } else if (rdx->processQueuedCommand<vector<int>>(id)) {
     } else if (rdx->processQueuedCommand<std::set<string>>(id)) {
     } else if (rdx->processQueuedCommand<unordered_set<string>>(id)) {
     } else
@@ -483,6 +484,7 @@ void Redox::freeQueuedCommands(struct ev_loop *loop, ev_async *async, int revent
     } else if (rdx->freeQueuedCommand<long long int>(id)) {
     } else if (rdx->freeQueuedCommand<nullptr_t>(id)) {
     } else if (rdx->freeQueuedCommand<vector<string>>(id)) {
+    } else if (rdx->freeQueuedCommand<vector<int>>(id)) {
     } else if (rdx->freeQueuedCommand<std::set<string>>(id)) {
     } else if (rdx->freeQueuedCommand<unordered_set<string>>(id)) {
     } else {
@@ -515,6 +517,7 @@ long Redox::freeAllCommands() {
          freeAllCommandsOfType<char *>() + freeAllCommandsOfType<int>() +
          freeAllCommandsOfType<long long int>() + freeAllCommandsOfType<nullptr_t>() +
          freeAllCommandsOfType<vector<string>>() + freeAllCommandsOfType<std::set<string>>() +
+         freeAllCommandsOfType<vector<int>>() +
          freeAllCommandsOfType<unordered_set<string>>();
 }
 
@@ -577,6 +580,10 @@ template <> unordered_map<long, Command<nullptr_t> *> &Redox::getCommandMap<null
 
 template <> unordered_map<long, Command<vector<string>> *> &Redox::getCommandMap<vector<string>>() {
   return commands_vector_string_;
+}
+
+template <> unordered_map<long, Command<vector<int>> *> &Redox::getCommandMap<vector<int>>() {
+  return commands_vector_int_;
 }
 
 template <> unordered_map<long, Command<set<string>> *> &Redox::getCommandMap<set<string>>() {

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -236,6 +236,17 @@ template <> void Command<vector<string>>::parseReplyObject() {
   }
 }
 
+template <> void Command<vector<int>>::parseReplyObject() {
+
+  if (!isExpectedReply(REDIS_REPLY_ARRAY))
+    return;
+
+  for (size_t i = 0; i < reply_obj_->elements; i++) {
+    redisReply *r = *(reply_obj_->element + i);
+    reply_val_.push_back(r->integer);
+  }
+}
+
 template <> void Command<unordered_set<string>>::parseReplyObject() {
 
   if (!isExpectedReply(REDIS_REPLY_ARRAY))
@@ -268,6 +279,7 @@ template class Command<int>;
 template class Command<long long int>;
 template class Command<nullptr_t>;
 template class Command<vector<string>>;
+template class Command<vector<int>>;
 template class Command<set<string>>;
 template class Command<unordered_set<string>>;
 


### PR DESCRIPTION
Some Redis commands, such as `SMISMEMBER`, return a list of integers. Trying to treat the reply as a vector<string> doesn't work because the reply object has already parsed the data as integers, not strings. Supporting this is a simple change.

I've added an example of the usage in `examples/data_types.cpp`. It now prints:
```
Last 5 elements as a vector: 10 9 8 7 6 
Last 5 elements as a hash: 10 8 7 9 6 
Last 5 elements as a set: 10 6 7 8 9 
Are {1, 2, 3, 4, 5} in the set, respectively: 0 1 1 0 1 
```